### PR TITLE
test: move DotGenerator test to tests/unit

### DIFF
--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -4,9 +4,6 @@
 
 import logging
 
-import pydot
-
-from expertsystem.topology.graph import DotGenerator
 from expertsystem.ui import StateTransitionManager
 
 
@@ -33,10 +30,6 @@ def test_script():
         print(solution.edge_props[1]["Name"])
 
     stm.write_amplitude_model(solutions, "D0ToKs0KpKm.xml")
-
-    for i in solutions:
-        dot_data = DotGenerator.from_graph(i)
-        assert pydot.graph_from_dot_data(dot_data) is not None
 
 
 if __name__ == "__main__":

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -1,0 +1,9 @@
+import pydot
+
+from expertsystem.topology.graph import DotGenerator
+
+
+def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions):
+    for i in jpsi_to_gamma_pi_pi_helicity_solutions:
+        dot_data = DotGenerator.from_graph(i)
+        assert pydot.graph_from_dot_data(dot_data) is not None


### PR DESCRIPTION
Uses https://github.com/ComPWA/expertsystem/pull/220 to test the `DotGenerator` under the 'faster' unit tests.

Note that this does not yet address https://github.com/ComPWA/expertsystem/pull/216#issuecomment-675548443